### PR TITLE
 a more appropriate translation

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -149,7 +149,7 @@ Julia 的目标是创建一个前所未有的集易用、强大、高效于一�
   * 用户定义的类型和内建类型一样快和兼容
   * 无需特意编写向量化的代码；非向量化的代码就很快
   * 为并行计算和分布式计算设计
-  * 轻量级的“绿色”线程（([协程](https://en.wikipedia.org/wiki/Coroutine))）
+  * 轻量级的“绿色”线程 ([协程](https://en.wikipedia.org/wiki/Coroutine))
   * 低调又牛逼的类型系统
   * 优雅、可扩展的类型转换
   * 高效支持[Unicode](https://en.wikipedia.org/wiki/Unicode)，包括但不限于[UTF-8](https://en.wikipedia.org/wiki/UTF-8)

--- a/zh_CN/doc/src/manual/getting-started.md
+++ b/zh_CN/doc/src/manual/getting-started.md
@@ -101,4 +101,4 @@ julia [switches] -- [programfile] [args...]
 
 ## 资源
 
-除了本手册以外，官方网站上还有很多其它可以帮助新用户学习 Julia 的资源（英文），这里是一个学习资源的列表：[learning](https://julialang.org/learning/)
+除了本手册以外，官方网站还提供了一个有用的[学习资源列表](https://julialang.org/learning/)来帮助新用户学习 Julia。

--- a/zh_CN/doc/src/manual/getting-started.md
+++ b/zh_CN/doc/src/manual/getting-started.md
@@ -101,4 +101,4 @@ julia [switches] -- [programfile] [args...]
 
 ## 资源
 
-除了本手册以外，官方网站还提供了一个有用的[学习资源列表](https://julialang.org/learning/)来帮助新用户学习 Julia。
+除了本手册以外，官方网站还提供了一个有用的**[学习资源列表](https://julialang.org/learning/)**来帮助新用户学习 Julia。


### PR DESCRIPTION
Here, I made minor revision of the translation so that the link (url) of the learning page on the official website can appear in an obvious way as “学习资源列表”