### PR TITLE
Use gitlab-ci for building and deploying docs instead of travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ doc/deps
 _*.dat
 *.swp
 __pycache__/
+Manifest.toml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,16 +3,11 @@ image: julia:1.0.0-stretch
 before_script:
   - julia --version
 
-test:
-  script:
-    - cp -r zh_CN/* ./
-    - julia --project --check-bounds=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
-
 pages:
   stage: deploy
   script:
     - cp -r zh_CN/* ./
-    - julia --project --check-bounds=yes --color=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
+    - DOCUMENTER_DEBUG=true julia --project --check-bounds=yes --color=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
     - mv doc/build public
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,12 +5,12 @@ before_script:
 
 test:
   script:
-    - julia --project --check-bounds=yes -e 'using Pkg; Pkg.add("Documenter")'
+    - julia --project --check-bounds=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
 
 pages:
   stage: deploy
   script:
-    - julia --project --check-bounds=yes --color=yes -e 'include("doc/make.jl")'
+    - julia --project --check-bounds=yes --color=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
     - mv doc/build public
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+image: julia:1.0.0-stretch
+
+before_script:
+  - julia --version
+
+test:
+  script:
+    - julia --project --check-bounds=yes -e 'using Pkg; Pkg.add("Documenter")'
+
+pages:
+  stage: deploy
+  script:
+    - julia --project --check-bounds=yes --color=yes -e 'include("doc/make.jl")'
+    - mv doc/build public
+  artifacts:
+    paths:
+      - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,17 @@ image: julia:1.0.0-stretch
 
 before_script:
   - julia --version
+  - echo $TRAVIS_BRANCH
+  - echo $TRAVIS_PULL_REQUEST
+  - echo $TRAVIS_REPO_SLUG
+  - echo $TRAVIS_OS_NAME
+  - echo $TRAVIS_JULIA_VERSION
 
 pages:
   stage: deploy
   script:
     - cp -r zh_CN/* ./
-    - DOCUMENTER_DEBUG=true julia --project --check-bounds=yes --color=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
+    - TRAVIS_TAG=CI_COMMIT_TAG DOCUMENTER_DEBUG=true julia --project --check-bounds=yes --color=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
     - mv doc/build public
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,13 @@ before_script:
 
 test:
   script:
+    - cp -r zh_CN/* ./
     - julia --project --check-bounds=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
 
 pages:
   stage: deploy
   script:
+    - cp -r zh_CN/* ./
     - julia --project --check-bounds=yes --color=yes -e 'using Pkg; Pkg.add("Documenter"); include("doc/make.jl")'
     - mv doc/build public
   artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,26 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+
 os:
   - linux
   - osx
+
 julia:
   - 0.7
   - 1.0
   - nightly
+
 notifications:
   email: false
+
 git:
   depth: 99999999
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
+matrix:
+ allow_failures:
+ - julia: nightly
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:
@@ -28,11 +32,7 @@ git:
 
 ## uncomment the following lines to override the default test script
 script:
- # - julia -e 'Pkg.clone(pwd()); Pkg.build("JuliaZH"); Pkg.test("JuliaZH"; coverage=true)'
- # build docs
- - julia -e 'using Pkg; Pkg.add("Documenter")'
- - cp -r zh_CN/* ./
- - cd doc && julia make.jl
+ - julia -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.test()'
 
 after_success:
   # # push coverage results to Coveralls

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,5 @@
+name = "JuliaZH"
+uuid = "4902c878-a2be-11e8-373b-bfd5ea96e765"
+version = "0.1.0"
+
+[deps]

--- a/Project.toml
+++ b/Project.toml
@@ -3,3 +3,4 @@ uuid = "4902c878-a2be-11e8-373b-bfd5ea96e765"
 version = "0.1.0"
 
 [deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -42,19 +42,6 @@ search: JuliaZH
   退出REPL之后，重新进入将恢复英文模式。
 ```
 
-<!--
-Julia 0.7+ 请使用自带的包管理器安装
-
-```julia
-pkg> add JuliaZH
-```
-
-Julia 0.6 请在REPL中使用如下命令
-
-```julia
-julia> Pkg.add("JuliaZH")
-``` -->
-
 ## 贡献文档
 
 请阅读[JuliaZH的开发文档](https://juliacn.github.io/JuliaZH.jl/latest/juliacn/style-guide/)并给我们提交PR或者通过issue讨论。

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7
-Compat

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -85,8 +85,8 @@ const PAGES = [
         "base/stacktraces.md",
         "base/simd-types.md",
     ],
-    # "Standard Library" =>
-    #     [stdlib.targetfile for stdlib in STDLIB_DOCS],
+    "Standard Library" =>
+        [stdlib.targetfile for stdlib in STDLIB_DOCS],
     "Developer Documentation" => [
         "devdocs/reflection.md",
         "Documentation of Julia's Internals" => [
@@ -129,7 +129,7 @@ end
 
 # make documents
 makedocs(
-    modules   = [Base, Core],
+    modules   = [Base, Core, [Base.root_module(Base, stdlib.stdlib) for stdlib in STDLIB_DOCS]...],
     clean     = false,
     doctest   = false,
     linkcheck = "linkcheck=true" in ARGS,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,2 @@
 using JuliaZH
-@static if VERSION < v"0.7.0-DEV.2005"
-    using Base.Test
-else
-    using Test
-end
+using Test


### PR DESCRIPTION
As per #26, travis-ci appears to be very buggy when building stdlib docs. I'm wondering if there is any chance to use gitlab-ci + Julia official docker image for doc deploying. Some experiments:  

https://gitlab.com/JuliaCN/JuliaZH.jl

https://juliacn.gitlab.io/JuliaZH.jl/