### PR TITLE
use PkgServerClient to choose the best mirror server as pkg server

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,11 @@ uuid = "652e05fd-ed22-5b6c-bf99-44e63a676e5f"
 version = "1.5.4"
 
 [deps]
+PkgServerClient = "9c9e696b-6b05-402c-8ae4-5dc38852c714"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
+PkgServerClient = "0.1"
 julia = "1"
 
 [extras]

--- a/src/JuliaZH.jl
+++ b/src/JuliaZH.jl
@@ -2,86 +2,17 @@ module JuliaZH
 
 import Base.Docs: DocStr
 
+# early version of JuliaZH provides these two methods
+import PkgServerClient: set_mirror, generate_startup
+
 const keywords = Dict{Symbol,DocStr}()
 
-"""
-源列表
-"""
-const mirrors = Dict{String,String}()
-
-mirrors["BFSU"] = "https://mirrors.bfsu.edu.cn/julia"
-mirrors["TUNA"] = "https://mirrors.tuna.tsinghua.edu.cn/julia"
-mirrors["default"] = "https://pkg.julialang.org"
-mirrors["SJTUG"] = "https://mirrors.sjtug.sjtu.edu.cn/julia"
-mirrors["USTC"] = "https://mirrors.ustc.edu.cn/julia"
-mirrors["OpenTUNA"] = "https://opentuna.cn/julia"
-
-"""
-    set_mirror(mirror_name="BFSU")
-
-设置镜像源为 `mirror_name`。目前可以选择的有：
-
-- `"BFSU"`: 北京外国语大学开源软件镜像站
-- `"TUNA"`: 清华大学开源软件镜像站 -- TUNA 协会
-- `"SJTUG"`: 上海交通大学Linux用户组 (SJTUG) 软件源镜像服务
-- `"USTC"`: 中国科学技术大学开源软件镜像
-- `"OpenTUNA"`: OpenTUNA开源镜像站 -- TUNA 协会
-- `"default"`: Julia官方默认源
-"""
-function set_mirror(mirror_name = "BFSU")
-    ENV["JULIA_PKG_SERVER"] = mirrors[mirror_name]
-    return
-end
-
-const regex_PKG_SERVER = r"^\s*[^#]*\s*(ENV\[\"JULIA_PKG_SERVER\"\]\s*=\s*)\"([\w\.:\/]*)\""
-
-"""
-    generate_startup(mirror_name::String="BFSU")
-自动产生将镜像设置到 `mirror_name` 的 `startup.jl` 文件。默认值是 `BFSU
-` 的源。
-"""
-function generate_startup(mirror_name::String = "BFSU")
-    default_dot_julia = first(DEPOT_PATH)
-    config_path = joinpath(default_dot_julia, "config")
-    if !ispath(config_path)
-        mkpath(config_path)
-    end
-
-    startup_path = joinpath(config_path, "startup.jl")
-    if ispath(startup_path)
-        startup_lines = readlines(startup_path)
-    else
-        startup_lines = String[]
-    end
-
-    new_upstream = mirrors[mirror_name]
-    new_line = "ENV[\"JULIA_PKG_SERVER\"] = \"$(new_upstream)\""
-    
-    pkg_matches = map(x->match(regex_PKG_SERVER, x), startup_lines)
-    pkg_indices = findall(x->!isnothing(x), pkg_matches)
-    if isempty(pkg_indices)
-        @info "添加 PkgServer" 服务器地址=new_upstream 配置文件=startup_path
-        append!(startup_lines, ["", "# 以下这一行由 JuliaCN 自动生成", new_line, ""])
-    else
-        # only modify the last match
-        idx = last(pkg_indices)
-        old_upstream = pkg_matches[idx].captures[2]
-
-        is_upstream_unchanged = occursin(new_upstream, old_upstream) || occursin(old_upstream, new_upstream)
-        if !is_upstream_unchanged
-            @info "更新 PkgServer" 新服务器地址=new_upstream 原服务器地址=old_upstream 配置文件=startup_path
-            startup_lines[idx] = new_line
-        end
-    end
-
-    write(startup_path, join(startup_lines, "\n"))
-    return
-end
-
 function __init__()
+    # Set pkg server to the nearest mirror
+    @eval using PkgServerClient
+
     # set to Chinese env by default
     ENV["REPL_LOCALE"] = "zh_CN"
-    set_mirror("BFSU")
     if ccall(:jl_generating_output, Cint, ()) == 0
         include(joinpath(@__DIR__, "i18n_patch.jl"))
         include(joinpath(@__DIR__, "basedocs.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
-using JuliaZH
 using Test
+
+ENV["JULIA_PKG_SERVER"] = ""
+using JuliaZH
+@test !isempty(ENV["JULIA_PKG_SERVER"])
 
 @testset "check ENV" begin
     @test ENV["REPL_LOCALE"] == "zh_CN"
-    @test ENV["JULIA_PKG_SERVER"] == "https://mirrors.bfsu.edu.cn/julia/static"
 end


### PR DESCRIPTION
closes #120 

- [ ] require https://github.com/JuliaRegistries/General/pull/32878

我将镜像站的切换功能重写到 PkgServerClient 里面了，并且增加了自动切换到最近的镜像站的功能：

```julia
julia> versioninfo()
Julia Version 1.6.0
Commit f9720dc2eb (2021-03-24 12:55 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin19.6.0)
  CPU: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)

julia> using JuliaZH

julia> versioninfo()
Julia Version 1.6.0
Commit f9720dc2eb (2021-03-24 12:55 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin19.6.0)
  CPU: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
Environment:
  JULIA_PKG_SERVER = https://opentuna.cn/julia

julia> using JuliaZH: PkgServerClient

# 测试镜像站延迟
julia> PkgServerClient.registry_response_time()
Dict{String, Float64} with 8 entries:
  "BFSU"      => 0.106639
  "OpenTUNA"  => 0.335531
  "SJTUG"     => 0.101141
  "USTC"      => 0.0674178
  "SUSTech"   => 0.0906177
  "TUNA"      => 0.114346
  "JuliaLang" => 0.844634
  "NJU"       => 0.0908128
```

因为是选择延迟最低的镜像站，所以 `JULIA_PKG_SERVER` 的具体值是不确定的。之前我们是硬编码到了BFSU.

这个PR之后我们需要更新上游镜像站的帮助文档。