### PR TITLE
CI: 拆分 PDF 构建流程、更新 CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,3 +40,8 @@ jobs:
         run: |
           julia -e 'include("contrib/build_sysimg.jl"); build_sysimg(force=true)'
           julia --project=doc/ doc/make.jl deploy
+      - name: Upload HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-site
+          path: doc/build/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   HTML:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
+          version: '1.8'
           show-versioninfo: true
       - uses: julia-actions/cache@v2
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,16 +11,17 @@ jobs:
   HTML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.8"
+          version: '1.10'
+          show-versioninfo: true
       - name: Install dependencies
+        shell: julia --project=docs --color=yes {0}
         run: |
-          julia --project=docs/ -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,12 +10,17 @@ on:
 jobs:
   HTML:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      contents: write
+      statuses: write
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
           show-versioninfo: true
+      - uses: julia-actions/cache@v2
       - name: Install dependencies
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,18 +27,3 @@ jobs:
         run: |
           julia -e 'include("contrib/build_sysimg.jl"); build_sysimg(force=true)'
           julia --project=doc/ doc/make.jl deploy
-  PDF:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build and deploy
-        timeout-minutes: 90
-        uses: JuliaCN/documenter-latex-action@v0.1.0
-        with:
-          project_dir: 'doc'
-          format: pdf # trigger the pdf compilation in our doc/make.jl
-      - name: upload complied PDF file
-        uses: actions/upload-artifact@v2
-        with:
-          name: compiled contents
-          path: doc/build/*.pdf

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,0 +1,24 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  PDF:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and deploy
+        timeout-minutes: 90
+        uses: JuliaCN/documenter-latex-action@v0.1.0
+        with:
+          project_dir: 'doc'
+          format: pdf # trigger the pdf compilation in our doc/make.jl
+      - name: upload complied PDF file
+        uses: actions/upload-artifact@v2
+        with:
+          name: compiled contents
+          path: doc/build/*.pdf


### PR DESCRIPTION
准备同步文档版本，先做一点升级，避免一个 pr 混杂了太多的东西。

pr 包含的修改：
- 拆分了 PDF 构建的流程，只在 master 分支的提交上运行
- docs 分支会在 push 和 pr 上运行
- 更新了 docs CI 的操作版本
	- 参考 https://github.com/JuliaCI/PkgTemplates.jl/blob/master/templates/github/workflows/CI.yml

已知问题：
- `.github/workflows/pdf.yml`: 目前是无效的流程，因为 actions/checkout@v2 还没更新。
	故意没升级，等待后续 PR 升级
- julia 版本没升级到 v1.10：需要和 doc/make.jl 一起升级
