### PR TITLE
ci: 部署 PDF

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -29,6 +29,7 @@ jobs:
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
       - name: Build PDF
+        timeout-minutes: 90
         run: julia --project=doc/ doc/make.jl pdf texplatform=docker
       - name: upload complied PDF file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -30,7 +30,7 @@ jobs:
           Pkg.instantiate()
       - name: Build PDF
         timeout-minutes: 90
-        run: julia --project=doc/ doc/make.jl pdf texplatform=docker
+        run: julia --project=doc/ doc/make.jl deploy pdf texplatform=docker
       - name: upload complied PDF file
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -30,6 +30,9 @@ jobs:
           Pkg.instantiate()
       - name: Build PDF
         timeout-minutes: 90
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: julia --project=doc/ doc/make.jl deploy pdf texplatform=docker
       - name: upload complied PDF file
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
目前只上传到 CI 的工件，没有部署到网站上。

- 90 分钟超时
- 部署 PDF