### PR TITLE
Update asynchronous-programming.md

### DIFF
--- a/zh_CN/doc/src/manual/asynchronous-programming.md
+++ b/zh_CN/doc/src/manual/asynchronous-programming.md
@@ -161,7 +161,7 @@ taskHdl = @task mytask(7)
     [...]
     ```
 
-  * [`take!`](@ref) 和 [`fetch`](@ref) (只读取，不会将元素从 channel 中删掉)仍然可以从一个已经关闭的 channel 中读数据，直到 channel 被取空了为止。继续上面的例子：
+  * [`take!`](@ref) 和 [`fetch`](@ref) (只读取，不会将元素从 channel 中删掉）仍然可以从一个已经关闭的 channel 中读数据，直到 channel 被取空了为止。继续上面的例子：
      
 
     ```julia-repl


### PR DESCRIPTION
fix typo.
英文的`)`换去中文的`）`，与前面的开括号一致，并且在中文中更可读，因为中文的`）`更宽。