### PR TITLE
ci,doc: 使用稳定版的 Documenter.jl

### DIFF
--- a/doc/Project.toml
+++ b/doc/Project.toml
@@ -1,7 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-JuliaZH = "652e05fd-ed22-5b6c-bf99-44e63a676e5f"
+DocumenterInventoryWritingBackport = "195adf08-069f-4855-af3e-8933a2cdae94"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
-Documenter = "~1.10"  # OOM with v1.11 (#147)
+Documenter = "1"
 julia = "1.10"

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -9,6 +9,7 @@ using Pkg
 Pkg.instantiate()
 
 using Documenter
+using DocumenterInventoryWritingBackport
 include("../contrib/HTMLWriter.jl")
 include("../contrib/LaTeXWriter.jl")
 


### PR DESCRIPTION
Fix #147

- Revert "doc: use Documenter.jl v1.10 (#148)"
  This reverts commit 97feefd9c4215b7ced4bfdf1d86c8d1821642a8a.
